### PR TITLE
Update CustomCassandraConnectionFactory.java

### DIFF
--- a/src/main/java/CustomCassandraConnectionFactory.java
+++ b/src/main/java/CustomCassandraConnectionFactory.java
@@ -55,7 +55,7 @@ public class CustomCassandraConnectionFactory implements CassandraConnectionFact
                 .addContactPoints(hosts.toArray(new Inet4Address[0]))
                 .withPort(conf.port())
                 .withRetryPolicy(
-                        new MultipleRetryPolicy(conf.queryRetryCount(), conf.queryRetryDelay()))
+			new MultipleRetryPolicy(conf.queryRetryCount()))
                 .withReconnectionPolicy(
                         new ExponentialReconnectionPolicy(conf.minReconnectionDelayMillis(), conf.maxReconnectionDelayMillis()))
                 .withLoadBalancingPolicy(


### PR DESCRIPTION
Updating, due to QueryRetryDelay parameter dropped from Spark Cassandra connector
https://datastax-oss.atlassian.net/browse/SPARKC-423

